### PR TITLE
Exact depenency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   "license": "MIT",
   "dependencies": {
     "redis": "^2.6.0-2",
-    "redis-rstream": "^0.1.2",
-    "redis-wstream": "^0.2.5",
+    "redis-rstream": "0.1.2",
+    "redis-wstream": "0.2.5",
     "through2": "^2.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Makes `redis-rstream` and `redis-wstream` exact versions because of a bug in `redis-rstream@0.1.3`
See jeffbski/redis-rstream#4